### PR TITLE
Fix the relative imports matching node modules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 var path = require("path");
 var fs = require("fs");
 // Scan each module.paths. If there exists node_modules/moduleName then return true. Otherwise return false.
-var isNodeModule = function (moduleName) {
+var isNodeModule = function (_a) {
+    var moduleName = _a.moduleName;
     return module.paths.some(function (nodeModulePath) { return fs.existsSync(path.join(nodeModulePath, moduleName)); });
 };
 function default_1(styleApi) {
@@ -19,6 +20,10 @@ function default_1(styleApi) {
     var isStylesModule = function (_a) {
         var moduleName = _a.moduleName;
         return /\.(s?css|less)$/.test(moduleName);
+    };
+    var isAsset = function (_a) {
+        var moduleName = _a.moduleName;
+        return /\.(png|jpg|jpeg|gif|woff|woff2|ttf|eot)(\?.*)?$/i.test(moduleName);
     };
     var isTypescriptType = function (_a) {
         var type = _a.type;
@@ -45,22 +50,21 @@ function default_1(styleApi) {
         { separator: true },
         // Node modules
         {
-            match: function (imported) { return isNodeModule(imported.moduleName); },
+            match: and(isNodeModule, not(isRelativeModule)),
             sort: moduleName(naturally),
             sortNamedMembers: alias(unicode),
         },
         { separator: true },
-        // import … from "foo";
+        // Absolute imports
         {
             match: and(isAbsoluteModule, not(isStylesModule), not(isTypescriptType)),
             sort: moduleName(naturally),
             sortNamedMembers: alias(unicode),
         },
         { separator: true },
-        // import … from "./foo";
-        // import … from "../foo";
+        // Relative imports
         {
-            match: and(isRelativeModule, not(isStylesModule), not(isTypescriptType)),
+            match: and(isRelativeModule, not(isStylesModule), not(isTypescriptType), not(isAsset)),
             sort: [dotSegmentCount, moduleName(naturally)],
             sortNamedMembers: alias(unicode),
         },
@@ -72,6 +76,12 @@ function default_1(styleApi) {
             sortNamedMembers: alias(unicode),
         },
         { separator: true },
+        // Assets (images, fonts, etc)
+        {
+            match: isAsset,
+            sort: [dotSegmentCount, moduleName(naturally)],
+            sortNamedMembers: alias(unicode),
+        },
         // import "./styles.less";
         { match: and(hasNoMember, isRelativeModule, isStylesModule) },
         { separator: true },

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import * as fs from "fs";
 import { IStyleAPI, IStyleItem } from "import-sort-style";
 
 // Scan each module.paths. If there exists node_modules/moduleName then return true. Otherwise return false.
-const isNodeModule = (moduleName) => {
+const isNodeModule = ({ moduleName }) => {
     return module.paths.some((nodeModulePath) => fs.existsSync(path.join(nodeModulePath, moduleName)));
 };
 
@@ -53,7 +53,7 @@ export default function (styleApi: IStyleAPI): IStyleItem[] {
 
         // Node modules
         {
-            match: (imported) => isNodeModule(imported.moduleName),
+            match: and(isNodeModule, not(isRelativeModule)),
             sort: moduleName(naturally),
             sortNamedMembers: alias(unicode),
         },


### PR DESCRIPTION
Relative imports with identical names to node_modules are not nod_modules, so don't consider them as such.

To see the imports that got caught by this visit this PR mention-me/MentionMe#8469